### PR TITLE
OIDC users now get admin-like privileges by default

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,15 +3,21 @@
 config:
   # By default, give OIDC users a role with the same rules as cluster-admin
   identity:
-    defaultUserNamespaceRole:
+    defaultUserClusterRole:
       rules:
         - apiGroups: ["*"]
           resources: ["*"]
           verbs: ["*"]
         - nonResourceURLs: ["*"]
           verbs: ["*"]
-    defaultUserClusterRole:
-      rules: []
+    # defaultUserNamespaceRole:
+    #   namespaces: ["default"]
+    #   rules:
+    #     - apiGroups: ["*"]
+    #       resources: ["*"]
+    #       verbs: ["*"]
+    #     - nonResourceURLs: ["*"]
+    #       verbs: ["*"]
 
 # A bundle of trusted CAs to use instead of the defaults
 trustBundle:


### PR DESCRIPTION
Cluster was previously unusable with OIDC enabled unless defaultUserNamespaceRole.namespaces was defined in config. Now that azimuth-authorization-webhook is available, it makes sense to just give users full read/write access from an RBAC perspective and rely on the webhook to block secret access