### PR TITLE
Ensure platform services updated in same thread as cluster status

### DIFF
--- a/azimuth_capi/operator.py
+++ b/azimuth_capi/operator.py
@@ -1290,7 +1290,6 @@ async def monitor_cluster_services(instance, name, namespace, **kwargs):
     ekclient_target = Configuration.from_kubeconfig_data(
         kubeconfig_data, json_encoder=pydantic_encoder
     ).async_client(default_field_manager=settings.easykube_field_manager)
-    ekclusterstatus = await ekresource_for_model(api.Cluster, "status")
     async with ekclient_target:
         try:
             ekzenithapi = ekclient_target.api(settings.zenith.api_version)

--- a/azimuth_capi/operator.py
+++ b/azimuth_capi/operator.py
@@ -1123,12 +1123,14 @@ async def on_cluster_secret_event(cluster, type, body, name, **kwargs):  # noqa:
         else:
             status.kubeconfig_secret_updated(cluster, body)
 
+
 async def update_platforms_for_cluster(instance: api.Cluster):
     """
     Updates Platform CR's with Zenith services from Cluster's services
     """
     realm = await find_realm(instance)
     await ensure_platform(instance, realm)
+
 
 @on_related_object_event(
     "addons.stackhpc.com",


### PR DESCRIPTION
Fixes a race where after upgrades, clusters services added to existing clusters don't get added to Platform CRs and are therefore don't have zenith endpoints created for them.
Removes `on_cluster_services_update` handler in favour of updating platform CRs within the same thread the cluster's `status.services` field is updated to avoid races presumably caused by divergent views of the cluster between easykube objects used to patch services into the cluster status and instance objects recorded by kopf handlers