### PR TITLE
DO NOT MERGE: PoC fix for cluster services race

### DIFF
--- a/azimuth_capi/models/v1alpha1/cluster.py
+++ b/azimuth_capi/models/v1alpha1/cluster.py
@@ -358,6 +358,9 @@ class ClusterStatus(schema.BaseModel, extra="allow"):
     last_updated: schema.Optional[dt.datetime] = Field(
         default=None, description="Used to trigger the timeout of pending states"
     )
+    finished: bool = Field(
+        True, description="semaphore"
+    )
 
 
 class Cluster(


### PR DESCRIPTION
Proof of concept fix for race described by `https://github.com/azimuth-cloud/azimuth-capi-operator/pull/481` (which will likely supersede this PR). `on_cluster_services_updated` now must wait on a `finished` field in the cluster's status before updating Platform CRs. I don't think this is a genuine fix, it just seems to delay monitor_cluster_services long enough for the race not to occur. Checking for `finished` being true also isn't atomic so in itself is race-prone, not sure what the implications of using regular async locks are for kopf threads