### PR TITLE
Allow control plane machine count to be set per cluster

### DIFF
--- a/azimuth_capi/models/v1alpha1/cluster.py
+++ b/azimuth_capi/models/v1alpha1/cluster.py
@@ -127,7 +127,7 @@ class ClusterSpec(schema.BaseModel):
     control_plane_machine_count: schema.Optional[schema.conint(ge=1)] = Field(
         None,
         description=(
-            "The number of control plane machines. "
+            "The number of control plane machines."
             "If not given, the value from the cluster template is used."
         ),
     )

--- a/azimuth_capi/models/v1alpha1/cluster.py
+++ b/azimuth_capi/models/v1alpha1/cluster.py
@@ -124,6 +124,13 @@ class ClusterSpec(schema.BaseModel):
     control_plane_machine_size: schema.constr(min_length=1) = Field(
         ..., description="The name of the size to use for control plane machines."
     )
+    control_plane_machine_count: schema.Optional[schema.conint(ge=1)] = Field(
+        None,
+        description=(
+            "The number of control plane machines. "
+            "If not given, the value from the cluster template is used."
+        ),
+    )
     node_groups: list[NodeGroupSpec] = Field(
         default_factory=list, description="The node groups for the cluster."
     )

--- a/azimuth_capi/models/v1alpha1/cluster.py
+++ b/azimuth_capi/models/v1alpha1/cluster.py
@@ -131,6 +131,14 @@ class ClusterSpec(schema.BaseModel):
             "If not given, the value from the cluster template is used."
         ),
     )
+    control_plane_etcd_volume_size: schema.Optional[schema.conint(ge=1)] = Field(
+        None,
+        description=(
+            "The size (in GB) of the Cinder volume used for etcd "
+            "when control_plane_machine_count is set. "
+            "Defaults to 20 if not specified."
+        ),
+    )
     node_groups: list[NodeGroupSpec] = Field(
         default_factory=list, description="The node groups for the cluster."
     )

--- a/azimuth_capi/templates/cluster-values.yaml
+++ b/azimuth_capi/templates/cluster-values.yaml
@@ -9,6 +9,9 @@ oidc:
 
 controlPlane:
   machineFlavor: "{{ spec.control_plane_machine_size }}"
+{% if spec.control_plane_machine_count %}
+  machineCount: {{ spec.control_plane_machine_count }}
+{% endif %}
   healthCheck:
     enabled: {{ "true" if spec.autohealing else "false" }}
 

--- a/azimuth_capi/templates/cluster-values.yaml
+++ b/azimuth_capi/templates/cluster-values.yaml
@@ -11,6 +11,9 @@ controlPlane:
   machineFlavor: "{{ spec.control_plane_machine_size }}"
 {% if spec.control_plane_machine_count %}
   machineCount: {{ spec.control_plane_machine_count }}
+  etcd:
+    blockDevice:
+      size: {{ spec.control_plane_etcd_volume_size or 20 }}
 {% endif %}
   healthCheck:
     enabled: {{ "true" if spec.autohealing else "false" }}

--- a/azimuth_capi/tests/test_operator.py
+++ b/azimuth_capi/tests/test_operator.py
@@ -244,3 +244,21 @@ class TestOperator(unittest.IsolatedAsyncioTestCase):
                 ],
             },
         )
+
+    def test_generate_helm_values_with_control_plane_count(self):
+        cluster = self.get_fake_cluster()
+        cluster.spec.control_plane_machine_count = 1
+        template = self.get_fake_cluster_template()
+
+        result = operator.generate_helm_values_for_release(
+            template, cluster, None, None, None, None
+        )
+
+        self.assertEqual(
+            result["controlPlane"],
+            {
+                "healthCheck": {"enabled": True},
+                "machineFlavor": "vm.small",
+                "machineCount": 1,
+            },
+        )

--- a/azimuth_capi/tests/test_operator.py
+++ b/azimuth_capi/tests/test_operator.py
@@ -260,5 +260,6 @@ class TestOperator(unittest.IsolatedAsyncioTestCase):
                 "healthCheck": {"enabled": True},
                 "machineFlavor": "vm.small",
                 "machineCount": 1,
+                "etcd": {"blockDevice": {"size": 20}},
             },
         )


### PR DESCRIPTION
Add an optional `controlPlaneMachineCount` field to `ClusterSpec`. When set, it overrides the `controlPlane.machineCount` defined in the cluster template, enabling operators to choose between a single-node and a 3-node HA control plane at cluster creation time.

Clusters that do not specify this field continue to use the count defined in their template, preserving backwards compatibility.