### PR TITLE
Don't run Helm upgrade every cluster create retry

### DIFF
--- a/azimuth_capi/operator.py
+++ b/azimuth_capi/operator.py
@@ -714,7 +714,7 @@ async def on_cluster_create(logger, instance, name, namespace, patch, **kwargs):
             helm_values, await zenith_values(ekclient, instance, instance.spec.addons)
         )
     # Use Helm to install or upgrade the release
-    _ = await helm_client.install_or_upgrade_release(
+    _ = await helm_client.ensure_release(
         name,
         await helm_client.get_chart(
             settings.capi_helm.chart_name,


### PR DESCRIPTION
Use `ensure_release` to compare Helm values and only install/upgrade a Helm release for an openstack-cluster if the new values are different to the existing values.

Using `install_or_upgrade_release` forced a Helm upgrade with the same set of values every time the `on_cluster_create` function was fired.

Since https://github.com/azimuth-cloud/azimuth-capi-operator/pull/306, we make a `save_cluster_status()` call at the end of `on_cluster_create`, and if this encountered a temporary failure (like a conflict with another handler trying to update the cluster object), it caused the whole `on_cluster_create` function to be retried. As `install_or_upgrade_release` forced a Helm upgrade with the same set of values every time, this would **also** result in the cluster object being modified, creating _more_ contention and conflicts, leaving us stuck retrying `on_cluster_create` many times.

This issue is hugely exacerbated by updated CAPI/CAPO, which have much more rich event streams, and cause the 
`on_capi_cluster_event()`, `on_capi_controlplane_event()` and `on_capi_machine_event()` to fire more frequently, updating the cluster object. This has the knock-on effect of leaving us retrying `on_cluster_create` for ages.

Finally, because kopf gives us a single thread per object instance (cluster in this case), we were stuck so long in `on_cluster_create` that we missed the `on_cluster_services_updated` event and the related platform was never created.

This change ensures that we run `helm install` exactly once for each unique set of values, greatly reducing the cluster object update storm/contention and allowing us to reliably catch the cluster services getting updated and create the platform for the cluster.